### PR TITLE
Update lerna.json: independent mode

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.0",
+  "version": "independant",
   "npmClient": "yarn",
   "useWorkspaces": true
 }


### PR DESCRIPTION
### Lerna configuration: independent mode, now all packages can use independent mode.

### ref.: https://github.com/lerna/lerna#independent-mode .

## Solves the problem: 
common-lib uses older version of prettier, but as main package enforces its version, the actual version being in action is newer one, so the deprecation warnings show up.

